### PR TITLE
avoid error at running

### DIFF
--- a/agent/release.Dockerfile
+++ b/agent/release.Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bookworm-slim AS release
 
 RUN apt-get update && apt-get install -y --no-install-recommends git \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /var/lib/apt/lists/*
 
 # Use binaly built by goreleaser
 COPY agent /usr/local/bin/agent


### PR DESCRIPTION
Error caused at running agent container by empty line err on docker image. Fix it.