### PR TITLE
replace panic with error handling

### DIFF
--- a/agent/cli/command_create_pr.go
+++ b/agent/cli/command_create_pr.go
@@ -48,7 +48,10 @@ func CreatePR(flags []string) error {
 		return err
 	}
 
-	gh := newGitHub()
+	gh, err := newGitHub()
+	if err != nil {
+		return fmt.Errorf("failed to create GitHub client: %w", err)
+	}
 
 	ctx := context.Background()
 	var issLoader loader.Loader
@@ -76,10 +79,10 @@ func isPassedConfig(configPath string) bool {
 	return configPath != ""
 }
 
-func newGitHub() *github.Client {
+func newGitHub() (*github.Client, error) {
 	token, ok := os.LookupEnv("GITHUB_TOKEN")
 	if !ok {
-		panic("GITHUB_TOKEN is not set")
+		return nil, fmt.Errorf("GITHUB_TOKEN is not set")
 	}
-	return github.NewClient(nil).WithAuthToken(token)
+	return github.NewClient(nil).WithAuthToken(token), nil
 }

--- a/agent/models/anthropic_llm_forwarder.go
+++ b/agent/models/anthropic_llm_forwarder.go
@@ -14,15 +14,15 @@ type AnthropicLLMForwarder struct {
 	anthropic AnthropicClient
 }
 
-func NewAnthropicLLMForwarder(l logger.Logger) LLMForwarder {
+func NewAnthropicLLMForwarder(l logger.Logger) (LLMForwarder, error) {
 	token, ok := os.LookupEnv("ANTHROPIC_API_KEY")
 	if !ok {
-		panic("ANTHROPIC_API_KEY is not set")
+		return nil, fmt.Errorf("ANTHROPIC_API_KEY is not set")
 	}
 
 	return AnthropicLLMForwarder{
 		anthropic: NewAnthropic(l, token),
-	}
+	}, nil
 }
 
 func (a AnthropicLLMForwarder) StartForward(input StartCompletionInput) ([]LLMMessage, error) {

--- a/agent/models/bedrock_llm_forwarder.go
+++ b/agent/models/bedrock_llm_forwarder.go
@@ -20,15 +20,14 @@ type BedrockLLMForwarder struct {
 	Bedrock BedrockClient
 }
 
-func NewBedrockLLMForwarder(l logger.Logger) LLMForwarder {
+func NewBedrockLLMForwarder(l logger.Logger) (LLMForwarder, error) {
 	bed, err := NewBedrock(l)
 	if err != nil {
-		l.Error("failed to create bedrock client: %v", err)
-		panic(err)
+		return nil, err
 	}
 	return BedrockLLMForwarder{
 		Bedrock: bed,
-	}
+	}, nil
 }
 
 func (a BedrockLLMForwarder) StartForward(input StartCompletionInput) ([]LLMMessage, error) {

--- a/agent/models/openai_llm_forwarder.go
+++ b/agent/models/openai_llm_forwarder.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/clover0/issue-agent/functions"
@@ -13,15 +14,15 @@ type OpenAILLMForwarder struct {
 	openai OpenAI
 }
 
-func NewOpenAILLMForwarder(l logger.Logger) LLMForwarder {
+func NewOpenAILLMForwarder(l logger.Logger) (LLMForwarder, error) {
 	apiKey, ok := os.LookupEnv("OPENAI_API_KEY")
 	if !ok {
-		panic("OPENAI_API_KEY is not set")
+		return nil, fmt.Errorf("OPENAI_API_KEY is not set")
 	}
 
 	return OpenAILLMForwarder{
 		openai: NewOpenAI(l, apiKey),
-	}
+	}, nil
 }
 
 func (o OpenAILLMForwarder) StartForward(input StartCompletionInput) ([]LLMMessage, error) {

--- a/agent/models/selector.go
+++ b/agent/models/selector.go
@@ -10,14 +10,14 @@ import (
 
 func SelectForwarder(lo logger.Logger, model string) (LLMForwarder, error) {
 	if util.IsAWSBedrockModel(model) {
-		return NewBedrockLLMForwarder(lo), nil
+		return NewBedrockLLMForwarder(lo)
 	}
 	if strings.HasPrefix(model, "gpt") {
-		return NewOpenAILLMForwarder(lo), nil
+		return NewOpenAILLMForwarder(lo)
 	}
 
 	if strings.HasPrefix(model, "claude") {
-		return NewAnthropicLLMForwarder(lo), nil
+		return NewAnthropicLLMForwarder(lo)
 	}
 
 	if model == "" {


### PR DESCRIPTION
Replaced panics with proper error handling in forwarder constructors to improve robustness.
Adjustments were made to propagate errors in creating API clients (e.g., missing environment variables) instead of halting execution. 