### PR TITLE
remove support for external prompt file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /*.iml
 
 # Project
+.env*
 .tmp
 issue_agent.yml
 

--- a/agent/cmd/runner/main.go
+++ b/agent/cmd/runner/main.go
@@ -49,11 +49,6 @@ func run(lo logger.Logger) error {
 		return err
 	}
 
-	promptPath, err := getPromptPath(conf)
-	if err != nil {
-		return err
-	}
-
 	flags, err := parseArgs(lo)
 	if err != nil {
 		return err
@@ -85,13 +80,6 @@ func run(lo logger.Logger) error {
 	// Mount files to the container
 	if len(configPath) > 0 {
 		args = append(args, "-v", configPath+":"+config.ConfigFilePath)
-	}
-	if len(promptPath) > 0 {
-		path, err := filepath.Abs(conf.Agent.PromptPath)
-		if err != nil {
-			return err
-		}
-		args = append(args, "-v", path+":"+config.PromptFilePath)
 	}
 	args = append(args, dockerEnvs...)
 	args = append(args, awsDockerEnvs...)
@@ -208,13 +196,6 @@ func getConfigPathOrDefault() (string, error) {
 	}
 
 	return path, nil
-}
-
-func getPromptPath(conf config.Config) (string, error) {
-	if len(conf.Agent.PromptPath) == 0 {
-		return "", nil
-	}
-	return filepath.Abs(conf.Agent.PromptPath)
 }
 
 // Pass only the environment variables that are required by the agent.

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -15,7 +15,6 @@ var defaultConfig []byte
 
 const (
 	ConfigFilePath = "/agent/config/config.yml"
-	PromptFilePath = "/agent/config/prompt.yml"
 	DefaultWorkDir = "/agent/repositories"
 
 	LogDebug = "debug"
@@ -28,7 +27,6 @@ type Config struct {
 	WorkDir  string `yaml:"workdir"`
 	LogLevel string `yaml:"log_level" validate:"log_level"`
 	Agent    struct {
-		PromptPath   string `yaml:"prompt_path"`
 		Model        string `yaml:"model" validate:"required"`
 		MaxSteps     int    `yaml:"max_steps" validate:"gte=0"`
 		ReviewAgents int    `yaml:"review_agents"`

--- a/agent/config/default_config.yml
+++ b/agent/config/default_config.yml
@@ -11,11 +11,6 @@ workdir: "/tmp/repositories"
 log_level: "info"
 
 agent:
-  # Default prompt template is embed config.
-  # prompt_path is a relative path from the execution directory.
-  # e.g) config/prompt_template_en.yml
-  prompt_path: ""
-
   # Required
   # LLM name
   # The recommend model is Claude 3.5 Sonnet

--- a/agent/core/orchestrator.go
+++ b/agent/core/orchestrator.go
@@ -39,15 +39,9 @@ func OrchestrateAgents(
 		return err
 	}
 
-	promptPath := conf.Agent.PromptPath
-	if len(promptPath) > 0 {
-		// In container, the prompt file is mounted to `config.PromptFilePath`
-		promptPath = config.PromptFilePath
-	}
-	promptTemplate, err := coreprompt.LoadPrompt(promptPath)
+	promptTemplate, err := coreprompt.LoadPrompt()
 	if err != nil {
-		lo.Error("failed to load prompt template: %s\n", err)
-		return err
+		return fmt.Errorf("failed to load prompt template: %w\n", err)
 	}
 
 	// check if the base branch exists
@@ -85,7 +79,6 @@ func OrchestrateAgents(
 	issue, err := ghservice.GetIssue(issueNumber)
 	if err != nil {
 		return fmt.Errorf("failed to get issue: %w", err)
-
 	}
 
 	prompt, err := coreprompt.BuildRequirementPrompt(promptTemplate, conf.Language, baseBranch, issue)

--- a/agent/core/prompt/prompt_template.go
+++ b/agent/core/prompt/prompt_template.go
@@ -1,9 +1,6 @@
 package prompt
 
 import (
-	"io"
-	"os"
-
 	"gopkg.in/yaml.v3"
 
 	"github.com/clover0/issue-agent/config/template"
@@ -17,25 +14,10 @@ type PromptTemplate struct {
 	}
 }
 
-func LoadPrompt(filePath string) (PromptTemplate, error) {
+func LoadPrompt() (PromptTemplate, error) {
 	var pt PromptTemplate
 
-	var data []byte
-	if filePath == "" {
-		data = template.DefaultTemplate()
-	} else {
-		file, err := os.Open(filePath)
-		if err != nil {
-			return pt, err
-		}
-		defer file.Close()
-
-		data, err = io.ReadAll(file)
-		if err != nil {
-			return pt, err
-		}
-	}
-
+	data := template.DefaultTemplate()
 	err := yaml.Unmarshal(data, &pt)
 	if err != nil {
 		return pt, err

--- a/website/docs/configuration/yaml.md
+++ b/website/docs/configuration/yaml.md
@@ -16,11 +16,6 @@ workdir: "/tmp/repositories"
 log_level: "info"
 
 agent:
-  # Default prompt template is embed config.
-  # prompt_path is a relative path from the execution directory.
-  # e.g) config/prompt_template_en.yml
-  prompt_path: ""
-
   # Required
   # LLM name
   # The recommend model is Claude 3.5 Sonnet


### PR DESCRIPTION
Eliminates the ability to specify external prompt templates via `prompt_path`. 
The agent now exclusively relies on built-in default templates, simplifying configuration and reducing potential errors. 

Unused code, configuration fields, and documentation related to `prompt_path` have also been removed.