### PR TITLE
replace the SubmitFiles caller logic with a service-based abstraction

### DIFF
--- a/agent/agithub/submit_files_service.go
+++ b/agent/agithub/submit_files_service.go
@@ -15,163 +15,153 @@ import (
 	"github.com/clover0/issue-agent/logger"
 )
 
-// TODO: move to GitHub service
 type SubmitFileGitHubService struct {
-	owner      string
-	repository string
-	client     *github.Client
-	logger     logger.Logger
+	logger      logger.Logger
+	client      *github.Client
+	callerInput functions.SubmitFilesServiceInput
 }
 
 func NewSubmitFileGitHubService(
-	owner string,
-	repository string,
-	client *github.Client,
 	logger logger.Logger,
+	client *github.Client,
+	callerInput functions.SubmitFilesServiceInput,
 ) functions.SubmitFilesService {
 	return SubmitFileGitHubService{
-		owner:      owner,
-		repository: repository,
-		client:     client,
-		logger:     logger,
+		logger:      logger,
+		client:      client,
+		callerInput: callerInput,
 	}
 }
 
-// TODO: move to GitHub service
-func (s SubmitFileGitHubService) Caller(
-	ctx context.Context,
-	callerInput functions.SubmitFilesServiceInput,
-) functions.SubmitFilesCallerType {
+func (s SubmitFileGitHubService) SubmitFiles(input functions.SubmitFilesInput) (submitFileOut functions.SubmitFilesOutput, _ error) {
 	errorf := func(format string, a ...any) error {
 		return fmt.Errorf("submit file service: "+format, a...)
 	}
+	var err error
+	ctx := context.Background()
 
-	return func(input functions.SubmitFilesInput) (submitFileOut functions.SubmitFilesOutput, _ error) {
-		var err error
-
-		// TODO: validation before this caller
-		if callerInput.GitEmail == "" {
-			return submitFileOut, errorf("git email is not set")
-		}
-		if callerInput.GitName == "" {
-			return submitFileOut, errorf("git  name is not set")
-		}
-
-		repo, err := git.PlainOpen(".")
-		if err != nil {
-			return submitFileOut, errorf("failed to open repository: %w", err)
-		}
-
-		head, err := repo.Head()
-		if err != nil {
-			return submitFileOut, errorf("failed to get HEAD: %w", err)
-		}
-		if head.Name().Short() == callerInput.BaseBranch {
-			return submitFileOut, errorf("cannot submit in the base branch. create and switch to a new branch")
-		}
-
-		cfg, err := repo.Config()
-		if err != nil {
-			return submitFileOut, err
-		}
-
-		cfg.User.Email = callerInput.GitEmail
-		cfg.User.Name = callerInput.GitName
-
-		if err := repo.SetConfig(cfg); err != nil {
-			return submitFileOut, err
-		}
-
-		wt, err := repo.Worktree()
-		if err != nil {
-			return submitFileOut, errorf("failed to get worktree: %w", err)
-		}
-
-		if _, err := wt.Add("./"); err != nil {
-			return submitFileOut, errorf("failed to add files: %w", err)
-		}
-
-		status, err := wt.Status()
-		if err != nil {
-			return submitFileOut, errorf("failed to get worktree status: %w", err)
-		}
-
-		// reset symlink becauseb go-git's file system behavior causes symlinks to be relative paths, resulting in extra diffs.
-		for path := range status {
-			f, err := os.Lstat(path)
-			if err != nil {
-				return submitFileOut, fmt.Errorf("failed to open file %s: %w", path, err)
-			}
-			if f.Mode()&os.ModeSymlink != 0 {
-				s.logger.Debug(fmt.Sprintf("reset symlink: %s\n", path))
-				if err := wt.Reset(&git.ResetOptions{Files: []string{path}}); err != nil {
-					return submitFileOut, errorf("failed to reset symlink: %w", err)
-				}
-			}
-		}
-		s.logger.Info(status.String())
-
-		if _, err := wt.Commit(
-			fmt.Sprintf("%s\n\n%s", input.CommitMessageShort, input.CommitMessageDetail),
-			&git.CommitOptions{
-				Author: &object.Signature{
-					Name:  callerInput.GitName,
-					Email: callerInput.GitEmail,
-					When:  time.Now(),
-				},
-			}); err != nil {
-			return submitFileOut, errorf("failed to commit: %w", err)
-		}
-
-		if repo.Push(&git.PushOptions{RemoteName: "origin"}) != nil {
-			return submitFileOut, errorf("failed to push: %w", err)
-		}
-
-		ref, err := repo.Head()
-		if err != nil {
-			return submitFileOut, errorf("failed to get HEAD: %w", err)
-		}
-		currentBranch := ref.Name().Short()
-		prBranch := currentBranch
-
-		s.logger.Debug(fmt.Sprintf("created PR parameter: name=%s, email=%s, base-branch=%s branch=%s\n",
-			callerInput.GitName, callerInput.GitEmail, callerInput.BaseBranch, currentBranch))
-		pr, _, err := s.client.PullRequests.Create(ctx, s.owner, s.repository, &github.NewPullRequest{
-			Title: &input.CommitMessageShort,
-			Head:  &prBranch,
-			Base:  &callerInput.BaseBranch,
-			Body:  &input.PullRequestContent,
-		})
-		if err != nil {
-			return submitFileOut, errorf("failed to create PR: %w", err)
-		}
-
-		if len(callerInput.PRLabels) > 0 {
-			if _, _, err = s.client.Issues.AddLabelsToIssue(
-				ctx,
-				s.owner,
-				s.repository,
-				*pr.Number,
-				callerInput.PRLabels); err != nil {
-				return submitFileOut, errorf("failed to add labels(%s) to PR: %w", callerInput.PRLabels, err)
-			}
-		}
-
-		// checkout to the base branch
-		if err := wt.Checkout(&git.CheckoutOptions{
-			Branch: plumbing.NewBranchReferenceName(callerInput.BaseBranch),
-			Keep:   false,
-			Force:  true,
-			Create: false,
-		}); err != nil {
-			return submitFileOut, fmt.Errorf("failed to checkout branch %s: %w", callerInput.BaseBranch, err)
-		}
-
-		return functions.SubmitFilesOutput{
-			Message: fmt.Sprintf("success creating pull request.\ncreated pull request number: %d\nbranch: %s.\n switched %s branch.",
-				*pr.Number, prBranch, callerInput.BaseBranch),
-			PushedBranch:      prBranch,
-			PullRequestNumber: *pr.Number,
-		}, nil
+	// TODO: validation before this caller
+	if s.callerInput.GitEmail == "" {
+		return submitFileOut, errorf("git email is not set")
 	}
+	if s.callerInput.GitName == "" {
+		return submitFileOut, errorf("git  name is not set")
+	}
+
+	repo, err := git.PlainOpen(".")
+	if err != nil {
+		return submitFileOut, errorf("failed to open repository: %w", err)
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		return submitFileOut, errorf("failed to get HEAD: %w", err)
+	}
+	if head.Name().Short() == s.callerInput.BaseBranch {
+		return submitFileOut, errorf("cannot submit in the base branch. create and switch to a new branch")
+	}
+
+	cfg, err := repo.Config()
+	if err != nil {
+		return submitFileOut, err
+	}
+
+	cfg.User.Email = s.callerInput.GitEmail
+	cfg.User.Name = s.callerInput.GitName
+
+	if err := repo.SetConfig(cfg); err != nil {
+		return submitFileOut, err
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		return submitFileOut, errorf("failed to get worktree: %w", err)
+	}
+
+	if _, err := wt.Add("./"); err != nil {
+		return submitFileOut, errorf("failed to add files: %w", err)
+	}
+
+	status, err := wt.Status()
+	if err != nil {
+		return submitFileOut, errorf("failed to get worktree status: %w", err)
+	}
+
+	// reset symlink because go-git's file system behavior causes symlinks to be relative paths, resulting in extra diffs.
+	for path := range status {
+		f, err := os.Lstat(path)
+		if err != nil {
+			return submitFileOut, fmt.Errorf("failed to open file %s: %w", path, err)
+		}
+		if f.Mode()&os.ModeSymlink != 0 {
+			s.logger.Debug(fmt.Sprintf("reset symlink: %s\n", path))
+			if err := wt.Reset(&git.ResetOptions{Files: []string{path}}); err != nil {
+				return submitFileOut, errorf("failed to reset symlink: %w", err)
+			}
+		}
+	}
+	s.logger.Info(status.String())
+
+	if _, err := wt.Commit(
+		fmt.Sprintf("%s\n\n%s", input.CommitMessageShort, input.CommitMessageDetail),
+		&git.CommitOptions{
+			Author: &object.Signature{
+				Name:  s.callerInput.GitName,
+				Email: s.callerInput.GitEmail,
+				When:  time.Now(),
+			},
+		}); err != nil {
+		return submitFileOut, errorf("failed to commit: %w", err)
+	}
+
+	if repo.Push(&git.PushOptions{RemoteName: "origin"}) != nil {
+		return submitFileOut, errorf("failed to push: %w", err)
+	}
+
+	ref, err := repo.Head()
+	if err != nil {
+		return submitFileOut, errorf("failed to get HEAD: %w", err)
+	}
+	currentBranch := ref.Name().Short()
+	prBranch := currentBranch
+
+	s.logger.Debug(fmt.Sprintf("created PR parameter: name=%s, email=%s, base-branch=%s branch=%s\n",
+		s.callerInput.GitName, s.callerInput.GitEmail, s.callerInput.BaseBranch, currentBranch))
+	pr, _, err := s.client.PullRequests.Create(ctx, s.callerInput.GitHubOwner, s.callerInput.Repository, &github.NewPullRequest{
+		Title: &input.CommitMessageShort,
+		Head:  &prBranch,
+		Base:  &s.callerInput.BaseBranch,
+		Body:  &input.PullRequestContent,
+	})
+	if err != nil {
+		return submitFileOut, errorf("failed to create PR: %w", err)
+	}
+
+	if len(s.callerInput.PRLabels) > 0 {
+		if _, _, err = s.client.Issues.AddLabelsToIssue(
+			ctx,
+			s.callerInput.GitHubOwner,
+			s.callerInput.Repository,
+			*pr.Number,
+			s.callerInput.PRLabels); err != nil {
+			return submitFileOut, errorf("failed to add labels(%s) to PR: %w", s.callerInput.PRLabels, err)
+		}
+	}
+
+	// checkout to the base branch
+	if err := wt.Checkout(&git.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName(s.callerInput.BaseBranch),
+		Keep:   false,
+		Force:  true,
+		Create: false,
+	}); err != nil {
+		return submitFileOut, fmt.Errorf("failed to checkout branch %s: %w", s.callerInput.BaseBranch, err)
+	}
+
+	return functions.SubmitFilesOutput{
+		Message: fmt.Sprintf("success creating pull request.\ncreated pull request number: %d\nbranch: %s.\n switched %s branch.",
+			*pr.Number, prBranch, s.callerInput.BaseBranch),
+		PushedBranch:      prBranch,
+		PullRequestNumber: *pr.Number,
+	}, nil
 }

--- a/agent/cmd/list_functions/main.go
+++ b/agent/cmd/list_functions/main.go
@@ -19,9 +19,20 @@ func main() {
 
 	lo := logger.NewPrinter(conf.LogLevel)
 
+	ghClient := github.NewClient(nil).WithAuthToken("")
+	submitService := agithub.NewSubmitFileGitHubService(
+		lo, ghClient,
+		functions.SubmitFilesServiceInput{
+			BaseBranch: "main",
+			GitEmail:   conf.Agent.Git.UserEmail,
+			GitName:    conf.Agent.Git.UserName,
+			PRLabels:   conf.Agent.GitHub.PRLabels,
+		})
+
 	functions.InitializeFunctions(
 		*conf.Agent.GitHub.NoSubmit,
-		agithub.NewGitHubService(conf.Agent.GitHub.Owner, "test", github.NewClient(nil).WithAuthToken(""), lo),
+		agithub.NewGitHubService(conf.Agent.GitHub.Owner, "repo", ghClient, lo),
+		submitService,
 		conf.Agent.AllowFunctions,
 	)
 

--- a/agent/core/agent.go
+++ b/agent/core/agent.go
@@ -15,38 +15,35 @@ type AgentLike interface {
 }
 
 type Agent struct {
-	name                string
-	parameter           Parameter
-	currentStep         Step
-	logg                logger.Logger
-	submitServiceCaller functions.SubmitFilesCallerType
-	llmForwarder        LLMForwarder
-	prompt              prompt.Prompt
-	history             []LLMMessage
-	store               *store.Store
-	tools               []functions.Function
+	name         string
+	parameter    Parameter
+	currentStep  Step
+	logg         logger.Logger
+	llmForwarder LLMForwarder
+	prompt       prompt.Prompt
+	history      []LLMMessage
+	store        *store.Store
+	tools        []functions.Function
 }
 
 func NewAgent(
 	parameter Parameter,
 	name string,
 	logg logger.Logger,
-	submitServiceCaller functions.SubmitFilesCallerType,
 	prompt prompt.Prompt,
 	forwarder LLMForwarder,
 	store *store.Store,
 	tools []functions.Function,
 ) Agent {
 	return Agent{
-		name:                name,
-		parameter:           parameter,
-		currentStep:         Step{},
-		logg:                logg,
-		submitServiceCaller: submitServiceCaller,
-		prompt:              prompt,
-		llmForwarder:        forwarder,
-		store:               store,
-		tools:               tools,
+		name:         name,
+		parameter:    parameter,
+		currentStep:  Step{},
+		logg:         logg,
+		prompt:       prompt,
+		llmForwarder: forwarder,
+		store:        store,
+		tools:        tools,
 	}
 }
 
@@ -91,9 +88,6 @@ func (a *Agent) Work() (lastOutput string, err error) {
 					a.store,
 					fnCtx.Function.Name,
 					fnCtx.FunctionArgs.String(),
-					functions.SetSubmitFiles(
-						a.submitServiceCaller,
-					),
 				)
 
 				if err != nil {

--- a/agent/core/functions/submit_file_service.go
+++ b/agent/core/functions/submit_file_service.go
@@ -1,15 +1,15 @@
 package functions
 
-import "context"
-
 type SubmitFilesServiceInput struct {
-	BaseBranch string
-	GitEmail   string
-	GitName    string
-	PRLabels   []string
+	GitHubOwner string
+	Repository  string
+	BaseBranch  string
+	GitEmail    string
+	GitName     string
+	PRLabels    []string
 }
 
-type SubmitFilesCallerType func(input SubmitFilesInput) (SubmitFilesOutput, error)
+type SubmitFilesType func(input SubmitFilesInput) (SubmitFilesOutput, error)
 
 type SubmitFilesOutput struct {
 	Message           string
@@ -18,5 +18,5 @@ type SubmitFilesOutput struct {
 }
 
 type SubmitFilesService interface {
-	Caller(ctx context.Context, input SubmitFilesServiceInput) SubmitFilesCallerType
+	SubmitFiles(callerInput SubmitFilesInput) (SubmitFilesOutput, error)
 }

--- a/agent/core/functions/submit_files.go
+++ b/agent/core/functions/submit_files.go
@@ -2,11 +2,11 @@ package functions
 
 const FuncSubmitFiles = "submit_files"
 
-func InitSubmitFilesGitHubFunction() Function {
+func InitSubmitFilesGitHubFunction(service SubmitFilesService) Function {
 	f := Function{
 		Name:        FuncSubmitFiles,
 		Description: "Submit the modified files by Creation GitHub Pull Request",
-		Func:        SubmitFiles,
+		Func:        SubmitFileCaller(service),
 		Parameters: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
@@ -39,6 +39,8 @@ type SubmitFilesInput struct {
 	PullRequestContent  string `json:"pull_request_content"`
 }
 
-func SubmitFiles(submitting SubmitFilesCallerType, input SubmitFilesInput) (SubmitFilesOutput, error) {
-	return submitting(input)
+func SubmitFileCaller(service SubmitFilesService) SubmitFilesType {
+	return func(input SubmitFilesInput) (SubmitFilesOutput, error) {
+		return service.SubmitFiles(input)
+	}
 }


### PR DESCRIPTION
- Remove dependency `submitServiceCaller` from Agent structure
- Change SubmitFileGitHubService interface to use input structure for avoidance many arguments