### PR TITLE
remove flag from common input

### DIFF
--- a/agent/cli/input_common.go
+++ b/agent/cli/input_common.go
@@ -5,13 +5,12 @@ import (
 )
 
 type CommonInput struct {
-	Config       string
-	AWSProfile   string
-	AWSRegion    string
-	LogLevel     string
-	Language     string
-	Model        string
-	ReviewAgents int // TODO: remove from common. move to create-pr command.
+	Config     string
+	AWSProfile string
+	AWSRegion  string
+	LogLevel   string
+	Language   string
+	Model      string
 }
 
 func addCommonFlags(fs *flag.FlagSet, cfg *CommonInput) {
@@ -31,7 +30,4 @@ Default: English.`)
 
 	fs.StringVar(&cfg.Model, "model", "", "LLM name. For the model name, check the documentation of each LLM provider.")
 
-	fs.IntVar(&cfg.ReviewAgents, "review_agents", 0, `The number of agents to review.
-The number of agents to review. A value greater than 0 will review to the created PR.
-Default: 0`)
 }

--- a/agent/cli/input_create_pr.go
+++ b/agent/cli/input_create_pr.go
@@ -16,6 +16,7 @@ type CreatePRInput struct {
 	GithubIssueNumber string
 	WorkRepository    string `validate:"required"`
 	BaseBranch        string `validate:"required"`
+	ReviewAgents      int
 }
 
 func (c *CreatePRInput) MergeGitHubArg(pr ArgGitHubCreatePR) *CreatePRInput {
@@ -42,8 +43,8 @@ func (c *CreatePRInput) MergeConfig(conf config.Config) config.Config {
 		conf.Agent.GitHub.Owner = c.GitHubOwner
 	}
 
-	if c.Common.ReviewAgents > 0 {
-		conf.Agent.ReviewAgents = c.Common.ReviewAgents
+	if c.ReviewAgents > 0 {
+		conf.Agent.ReviewAgents = c.ReviewAgents
 	}
 
 	return conf
@@ -75,6 +76,8 @@ func CreatePRFlags() (*flag.FlagSet, *CreatePRInput) {
 	addCommonFlags(cmd, flagMapper.Common)
 
 	cmd.StringVar(&flagMapper.BaseBranch, "base_branch", "", "Base Branch for pull request")
+	cmd.IntVar(&flagMapper.ReviewAgents, "review_agents", 0, `The number of agents to review. A value greater than 0 will review to the created PR.
+Default: 0`)
 
 	return cmd, flagMapper
 }


### PR DESCRIPTION
Remove `review_agents` from common CLI input.
`review_agents`  is allowed in `create-pr` command.