### PR TITLE
add reviewers and team_reviewers flag to CLI input

### DIFF
--- a/agent/agithub/submit_files_service.go
+++ b/agent/agithub/submit_files_service.go
@@ -3,6 +3,7 @@ package agithub
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -151,6 +152,12 @@ func (s SubmitFileGitHubService) SubmitFiles(input functions.SubmitFilesInput) (
 		}
 	}
 
+	if len(s.callerInput.Reviewers) > 0 || len(s.callerInput.TeamReviewers) > 0 {
+		if err := s.reviewRequest(ctx, pr, s.callerInput.Reviewers, s.callerInput.TeamReviewers); err != nil {
+			return submitFileOut, errorf("failed to request reviewers: %w", err)
+		}
+	}
+
 	// checkout to the base branch
 	if err := wt.Checkout(&git.CheckoutOptions{
 		Branch: plumbing.NewBranchReferenceName(s.callerInput.BaseBranch),
@@ -167,6 +174,35 @@ func (s SubmitFileGitHubService) SubmitFiles(input functions.SubmitFilesInput) (
 		PushedBranch:      prBranch,
 		PullRequestNumber: *pr.Number,
 	}, nil
+}
+
+func (s SubmitFileGitHubService) reviewRequest(ctx context.Context, pr *github.PullRequest, reviewers []string, teamReviewers []string) error {
+	if _, resp, err := s.client.PullRequests.RequestReviewers(
+		ctx,
+		s.callerInput.GitHubOwner,
+		s.callerInput.Repository,
+		*pr.Number,
+		github.ReviewersRequest{
+			Reviewers:     reviewers,
+			TeamReviewers: teamReviewers,
+		}); err != nil {
+		if resp == nil {
+			return fmt.Errorf("failed to request reviewers=%s, team_reviewers=%s to PR: %w", s.callerInput.Reviewers, s.callerInput.TeamReviewers, err)
+		}
+
+		// if the client error caused, print the response body and continue
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return fmt.Errorf("failed to read response body: %w", err)
+			}
+			defer resp.Body.Close()
+
+			s.logger.Error("client error: %s\n", body)
+		}
+	}
+
+	return nil
 }
 
 // NopSubmitFileService implements functions.SubmitFilesService as a no-op service.

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -39,6 +39,8 @@ type Config struct {
 			CloneRepository *bool    `yaml:"clone_repository"`
 			Owner           string   `yaml:"owner" validate:"required"`
 			PRLabels        []string `yaml:"pr_labels"`
+			Reviewers       []string `yaml:"reviewers"`
+			TeamReviewers   []string `yaml:"team_reviewers"`
 		}
 		AllowFunctions []string `yaml:"allow_functions"`
 	} `yaml:"agent" validate:"required"`

--- a/agent/config/default_config.yml
+++ b/agent/config/default_config.yml
@@ -53,6 +53,12 @@ agent:
     pr_labels:
       - "issue-agent"
 
+    # The list of GitHub user `login` as reviewers. If you want to add multiple reviewers, separate them with a comma.
+    reviewers: ""
+
+    # The list of GitHub Team `slug` as team_reviewers If you want to add multiple team reviewers, separate them with a comma.
+    team_reviewers: ""
+
   # Allow agent to use function.
   # Belows are the default functions.
   allow_functions:

--- a/agent/core/functions/submit_file_service.go
+++ b/agent/core/functions/submit_file_service.go
@@ -1,12 +1,14 @@
 package functions
 
 type SubmitFilesServiceInput struct {
-	GitHubOwner string
-	Repository  string
-	BaseBranch  string
-	GitEmail    string
-	GitName     string
-	PRLabels    []string
+	GitHubOwner   string
+	Repository    string
+	BaseBranch    string
+	GitEmail      string
+	GitName       string
+	PRLabels      []string
+	Reviewers     []string
+	TeamReviewers []string
 }
 
 type SubmitFilesType func(input SubmitFilesInput) (SubmitFilesOutput, error)

--- a/agent/core/orchestrator.go
+++ b/agent/core/orchestrator.go
@@ -53,12 +53,14 @@ func OrchestrateAgentsByIssue(
 	submitService := agithub.NewSubmitFileGitHubService(
 		lo, gh,
 		functions.SubmitFilesServiceInput{
-			GitHubOwner: conf.Agent.GitHub.Owner,
-			Repository:  workRepository,
-			BaseBranch:  baseBranch,
-			GitEmail:    conf.Agent.Git.UserEmail,
-			GitName:     conf.Agent.Git.UserName,
-			PRLabels:    conf.Agent.GitHub.PRLabels,
+			GitHubOwner:   conf.Agent.GitHub.Owner,
+			Repository:    workRepository,
+			BaseBranch:    baseBranch,
+			GitEmail:      conf.Agent.Git.UserEmail,
+			GitName:       conf.Agent.Git.UserName,
+			PRLabels:      conf.Agent.GitHub.PRLabels,
+			Reviewers:     conf.Agent.GitHub.Reviewers,
+			TeamReviewers: conf.Agent.GitHub.TeamReviewers,
 		})
 	submitRevisionService := agithub.NopSubmitRevisionService{}
 

--- a/agent/test/assert/assert.go
+++ b/agent/test/assert/assert.go
@@ -7,26 +7,14 @@ import (
 
 func Equal[V comparable](t *testing.T, got, expected V) {
 	t.Helper()
-
-	gotIsPtr := reflect.TypeOf(got).Kind() == reflect.Pointer
-	expectedIsPtr := reflect.TypeOf(expected).Kind() == reflect.Pointer
-
-	// compare pointers
-	if gotIsPtr && expectedIsPtr {
-		if !reflect.ValueOf(got).Elem().Equal(reflect.ValueOf(expected).Elem()) {
-			t.Errorf(`assert.Equal(
-got: %v
-expected: %v
-)`, got, expected)
-		}
+	if reflect.DeepEqual(got, expected) {
 		return
-	}
-
-	if expected != got {
+	} else {
 		t.Errorf(`assert.Equal(
 got: %v
 expected: %v
 )`, got, expected)
+		return
 	}
 }
 

--- a/website/docs/configuration/command.md
+++ b/website/docs/configuration/command.md
@@ -34,6 +34,11 @@ Command and Flags
       The number of agents to review.
       If a value greater than 0 is specified, then that number of reviews will be performed by agents with different roles.
       Default: 0
+    --reviewers
+      The list of GitHub user `login` as reviewers. If you want to add multiple reviewers, separate them with a comma.
+    --team_reviewers
+      The list of GitHub Team `slug` as team_reviewers. If you want to add multiple team reviewers, separate them with a comma.
+
   react:
     Usage:
       react OWNER/REPO/issues/comments/COMMENT_ID [flags]


### PR DESCRIPTION
# New Feature
Added new two flags.

```
 --reviewers
   The list of GitHub user `login` as reviewers. If you want to add multiple reviewers, separate them with a comma.
 --team_reviewers
   The list of GitHub Team `slug` as team_reviewers. If you want to add multiple team reviewers, separate them with a comma.
```


## --reviewers
Example:
```
$ issue-agent create-pr --reviewers clover0
```

![image](https://github.com/user-attachments/assets/06213f60-2318-4373-bafd-fad722b06c35)


##  --team_reviewers
Example:
```
$ issue-agent create-pr --team_reviewers org/admin
```
![image](https://github.com/user-attachments/assets/6b64fd1a-1808-4c4c-a838-8fd67f713c89)
