### PR TITLE
modularize CLI command and input

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,7 +33,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - "-X github.com/clover0/issue-agent/cli.version={{ .Tag }}"
+      - "-X github.com/clover0/issue-agent/cli/command/version.version={{ .Tag }}"
 
 dockers:
   - id: issue-agent-amd64

--- a/agent/agithub/github.go
+++ b/agent/agithub/github.go
@@ -1,0 +1,16 @@
+package agithub
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/google/go-github/v69/github"
+)
+
+func NewGitHub() (*github.Client, error) {
+	token, ok := os.LookupEnv("GITHUB_TOKEN")
+	if !ok {
+		return nil, fmt.Errorf("GITHUB_TOKEN is not set")
+	}
+	return github.NewClient(nil).WithAuthToken(token), nil
+}

--- a/agent/cli/command/command.go
+++ b/agent/cli/command/command.go
@@ -1,9 +1,13 @@
-package cli
+package command
 
 import (
 	"fmt"
 	"os"
 
+	"github.com/clover0/issue-agent/cli/command/createpr"
+	"github.com/clover0/issue-agent/cli/command/help"
+	"github.com/clover0/issue-agent/cli/command/react"
+	"github.com/clover0/issue-agent/cli/command/version"
 	"github.com/clover0/issue-agent/logger"
 )
 
@@ -24,17 +28,17 @@ func Execute() error {
 
 	lo := logger.NewPrinter("info")
 	switch command {
-	case VersionCommand:
-		return Version()
-	case CreatePrCommand:
-		return CreatePR(others)
-	case ReactCommand:
-		return React(others)
-	case HelpCommand:
-		Help(lo)
+	case version.VersionCommand:
+		return version.Version()
+	case createpr.CreatePrCommand:
+		return createpr.CreatePR(others)
+	case react.ReactCommand:
+		return react.React(others)
+	case help.HelpCommand:
+		help.Help(lo)
 		return nil
 	default:
-		Help(lo)
+		help.Help(lo)
 		return fmt.Errorf("unknown command: %s", command)
 	}
 }

--- a/agent/cli/command/common/input_common.go
+++ b/agent/cli/command/common/input_common.go
@@ -1,4 +1,4 @@
-package cli
+package common
 
 import (
 	"flag"
@@ -13,7 +13,7 @@ type CommonInput struct {
 	Model      string
 }
 
-func addCommonFlags(fs *flag.FlagSet, cfg *CommonInput) {
+func AddCommonFlags(fs *flag.FlagSet, cfg *CommonInput) {
 	fs.StringVar(&cfg.Config, "config", "", `Path to the configuration file. 
 Default: agent/config/default_config.yml in this project.`)
 

--- a/agent/cli/command/createpr/command_create_pr.go
+++ b/agent/cli/command/createpr/command_create_pr.go
@@ -1,13 +1,12 @@
-package cli
+package createpr
 
 import (
 	"context"
 	"fmt"
 	"os"
 
-	"github.com/google/go-github/v69/github"
-
 	"github.com/clover0/issue-agent/agithub"
+	"github.com/clover0/issue-agent/cli/util"
 	"github.com/clover0/issue-agent/config"
 	"github.com/clover0/issue-agent/core"
 	"github.com/clover0/issue-agent/logger"
@@ -22,7 +21,7 @@ func CreatePR(flags []string) error {
 		return fmt.Errorf("failed to parse input: %w", err)
 	}
 
-	conf, err := config.LoadDefault(isPassedConfig(cliIn.Common.Config))
+	conf, err := config.LoadDefault(util.IsPassedConfig(cliIn.Common.Config))
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
@@ -48,7 +47,7 @@ func CreatePR(flags []string) error {
 		return err
 	}
 
-	gh, err := newGitHub()
+	gh, err := agithub.NewGitHub()
 	if err != nil {
 		return fmt.Errorf("failed to create GitHub client: %w", err)
 	}
@@ -56,16 +55,4 @@ func CreatePR(flags []string) error {
 	ctx := context.Background()
 
 	return core.OrchestrateAgentsByIssue(ctx, lo, conf, cliIn.BaseBranch, cliIn.WorkRepository, gh, cliIn.GithubIssueNumber, models.SelectForwarder)
-}
-
-func isPassedConfig(configPath string) bool {
-	return configPath != ""
-}
-
-func newGitHub() (*github.Client, error) {
-	token, ok := os.LookupEnv("GITHUB_TOKEN")
-	if !ok {
-		return nil, fmt.Errorf("GITHUB_TOKEN is not set")
-	}
-	return github.NewClient(nil).WithAuthToken(token), nil
 }

--- a/agent/cli/command/createpr/input_create_pr.go
+++ b/agent/cli/command/createpr/input_create_pr.go
@@ -1,4 +1,4 @@
-package cli
+package createpr
 
 import (
 	"flag"
@@ -7,11 +7,13 @@ import (
 
 	"github.com/go-playground/validator/v10"
 
+	"github.com/clover0/issue-agent/cli/command/common"
+	"github.com/clover0/issue-agent/cli/util"
 	"github.com/clover0/issue-agent/config"
 )
 
 type CreatePRInput struct {
-	Common            *CommonInput
+	Common            *common.CommonInput
 	GitHubOwner       string `validate:"required"`
 	GithubIssueNumber string
 	WorkRepository    string `validate:"required"`
@@ -85,12 +87,12 @@ func (c *CreatePRInput) Validate() error {
 
 func CreatePRFlags() (*flag.FlagSet, *CreatePRInput) {
 	flagMapper := &CreatePRInput{
-		Common: &CommonInput{},
+		Common: &common.CommonInput{},
 	}
 
 	cmd := flag.NewFlagSet("issue", flag.ExitOnError)
 
-	addCommonFlags(cmd, flagMapper.Common)
+	common.AddCommonFlags(cmd, flagMapper.Common)
 
 	cmd.StringVar(&flagMapper.BaseBranch, "base_branch", "", "Base Branch for pull request")
 	cmd.IntVar(&flagMapper.ReviewAgents, "review_agents", 0, `The number of agents to review. A value greater than 0 will review to the created PR.
@@ -123,7 +125,7 @@ func ParseCreatePRGitHubArg(arg string) (ArgGitHubCreatePR, error) {
 }
 
 func ParseCreatePRInput(argAndFlags []string) (CreatePRInput, error) {
-	arg, flags := ParseArgFlags(argAndFlags)
+	arg, flags := util.ParseArgFlags(argAndFlags)
 	ghIn, err := ParseCreatePRGitHubArg(arg)
 	if err != nil {
 		return CreatePRInput{}, fmt.Errorf("failed to parse arg: %w", err)

--- a/agent/cli/command/createpr/input_create_pr_test.go
+++ b/agent/cli/command/createpr/input_create_pr_test.go
@@ -1,4 +1,4 @@
-package cli
+package createpr
 
 import (
 	"testing"

--- a/agent/cli/command/help/command_help.go
+++ b/agent/cli/command/help/command_help.go
@@ -1,10 +1,12 @@
-package cli
+package help
 
 import (
 	"flag"
 	"fmt"
 	"strings"
 
+	"github.com/clover0/issue-agent/cli/command/createpr"
+	"github.com/clover0/issue-agent/cli/command/react"
 	"github.com/clover0/issue-agent/logger"
 )
 
@@ -17,12 +19,12 @@ Command and Flags
   help: Show usage of commands and flags
   version: Show version of issue-agent CLI
 `
-	createPRFlags, _ := CreatePRFlags()
-	reactFlags, _ := ReactFlags()
+	createPRFlags, _ := createpr.CreatePRFlags()
+	reactFlags, _ := react.ReactFlags()
 
-	msg += fmt.Sprintf("  %s:\n", CreatePrCommand)
+	msg += fmt.Sprintf("  %s:\n", createpr.CreatePrCommand)
 	msg += "    Usage:\n"
-	msg += fmt.Sprintf("      %s GITHUB_OWNER/REPOSITORY/issues/NUMBER [flags]\n", CreatePrCommand)
+	msg += fmt.Sprintf("      %s GITHUB_OWNER/REPOSITORY/issues/NUMBER [flags]\n", createpr.CreatePrCommand)
 	msg += "    Flags:\n"
 
 	createPRFlags.VisitAll(func(flg *flag.Flag) {
@@ -31,9 +33,9 @@ Command and Flags
 		msg += "\n"
 	})
 
-	msg += fmt.Sprintf("  %s:\n", ReactCommand)
+	msg += fmt.Sprintf("  %s:\n", react.ReactCommand)
 	msg += "    Usage:\n"
-	msg += fmt.Sprintf("      %s OWNER/REPO/issues/comments/COMMENT_ID [flags]\n", ReactCommand)
+	msg += fmt.Sprintf("      %s OWNER/REPO/issues/comments/COMMENT_ID [flags]\n", react.ReactCommand)
 	msg += "    Flags:\n"
 	reactFlags.VisitAll(func(flg *flag.Flag) {
 		msg += fmt.Sprintf("    --%s\n", flg.Name)

--- a/agent/cli/command/react/command_react.go
+++ b/agent/cli/command/react/command_react.go
@@ -1,10 +1,11 @@
-package cli
+package react
 
 import (
 	"fmt"
 	"os"
 
 	"github.com/clover0/issue-agent/agithub"
+	"github.com/clover0/issue-agent/cli/util"
 	"github.com/clover0/issue-agent/config"
 	"github.com/clover0/issue-agent/core"
 	"github.com/clover0/issue-agent/logger"
@@ -19,7 +20,7 @@ func React(flags []string) error {
 		return fmt.Errorf("failed to parse input: %w", err)
 	}
 
-	conf, err := config.LoadDefault(isPassedConfig(cliIn.Common.Config))
+	conf, err := config.LoadDefault(util.IsPassedConfig(cliIn.Common.Config))
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
@@ -32,7 +33,7 @@ func React(flags []string) error {
 
 	lo := logger.NewPrinter(conf.LogLevel)
 
-	gh, err := newGitHub()
+	gh, err := agithub.NewGitHub()
 	if err != nil {
 		return fmt.Errorf("failed to create GitHub client: %w", err)
 	}

--- a/agent/cli/command/react/input_react.go
+++ b/agent/cli/command/react/input_react.go
@@ -1,4 +1,4 @@
-package cli
+package react
 
 import (
 	"flag"
@@ -7,6 +7,8 @@ import (
 
 	"github.com/go-playground/validator/v10"
 
+	"github.com/clover0/issue-agent/cli/command/common"
+	"github.com/clover0/issue-agent/cli/util"
 	"github.com/clover0/issue-agent/config"
 )
 
@@ -18,7 +20,7 @@ type ArgGitHubReact struct {
 }
 
 type ReactInput struct {
-	Common         *CommonInput
+	Common         *common.CommonInput
 	GitHubOwner    string `validate:"required"`
 	GithubPRNumber string
 	WorkRepository string `validate:"required"`
@@ -91,19 +93,19 @@ func BindReactGitHubArg(arg string) (ArgGitHubReact, error) {
 
 func ReactFlags() (*flag.FlagSet, *ReactInput) {
 	flagMapper := &ReactInput{
-		Common: &CommonInput{},
+		Common: &common.CommonInput{},
 	}
 
 	cmd := flag.NewFlagSet("react", flag.ExitOnError)
 
-	addCommonFlags(cmd, flagMapper.Common)
+	common.AddCommonFlags(cmd, flagMapper.Common)
 
 	return cmd, flagMapper
 }
 
 // ParseReactInput
 func ParseReactInput(argAndFlags []string) (ReactInput, error) {
-	arg, flags := ParseArgFlags(argAndFlags)
+	arg, flags := util.ParseArgFlags(argAndFlags)
 	ghIn, err := BindReactGitHubArg(arg)
 	if err != nil {
 		return ReactInput{}, fmt.Errorf("failed to parse arg: %w", err)

--- a/agent/cli/command/version/command_version.go
+++ b/agent/cli/command/version/command_version.go
@@ -1,9 +1,9 @@
-package cli
+package version
 
 import "fmt"
 
 // This value is set at release build time
-// ldflags "-X github.com/clover0/issue-agent/cli.version=1.0.0)"
+// ldflags "-X github.com/clover0/issue-agent/cli/command/version.version=1.0.0)"
 var version = "development"
 
 const VersionCommand = "version"

--- a/agent/cli/util/util.go
+++ b/agent/cli/util/util.go
@@ -1,4 +1,4 @@
-package cli
+package util
 
 // ParseArgFlags parses the argument and flags from command line inputs.
 // Separate [inputs] to`arg` and `[flags]`.
@@ -11,4 +11,9 @@ func ParseArgFlags(argAndFlags []string) (string, []string) {
 	}
 
 	return argAndFlags[0], argAndFlags[1:]
+}
+
+// IsPassedConfig checks if the config path is passed.
+func IsPassedConfig(configPath string) bool {
+	return configPath != ""
 }

--- a/agent/cli/util/util_test.go
+++ b/agent/cli/util/util_test.go
@@ -1,4 +1,4 @@
-package cli
+package util
 
 import (
 	"testing"

--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/clover0/issue-agent/cli"
+	"github.com/clover0/issue-agent/cli/command"
 	"github.com/clover0/issue-agent/logger"
 )
 
@@ -13,7 +13,7 @@ func main() {
 	lo := logger.NewPrinter("info")
 	lo.Info("start agent in container...\n")
 
-	if err := cli.Execute(); err != nil {
+	if err := command.Execute(); err != nil {
 		lo.Error("failed to execute command: %s\n", err)
 		os.Exit(1)
 	}

--- a/agent/cmd/runner/main.go
+++ b/agent/cmd/runner/main.go
@@ -15,6 +15,7 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 
 	"github.com/clover0/issue-agent/cli"
+	"github.com/clover0/issue-agent/cli/command/createpr"
 	"github.com/clover0/issue-agent/config"
 	"github.com/clover0/issue-agent/logger"
 	"github.com/clover0/issue-agent/util"
@@ -125,8 +126,8 @@ func run(lo logger.Logger) error {
 	return nil
 }
 
-func parseArgs(lo logger.Logger) (*cli.CreatePRInput, error) {
-	flags, mapper := cli.CreatePRFlags()
+func parseArgs(lo logger.Logger) (*createpr.CreatePRInput, error) {
+	flags, mapper := createpr.CreatePRFlags()
 
 	start := 1
 	for i, arg := range os.Args {

--- a/agent/dev.Dockerfile
+++ b/agent/dev.Dockerfile
@@ -15,7 +15,7 @@ COPY . .
 # TODO: SLSA
 RUN cd /agent/src/cmd/agent && \
     CGO_ENABLED=0 go build \
-      -ldflags "-X github.com/clover0/issue-agent/cli.version=dev-$(date -u +'%Y-%m-%dT%H%M%SZ')" \
+      -ldflags "-X github.com/clover0/issue-agent/cli/command/version.version=dev-$(date -u +'%Y-%m-%dT%H%M%SZ')" \
       -o /agent/bin/agent
 
 


### PR DESCRIPTION
Reorganized the CLI codebase by modularizing commands into their own packages (e.g., createpr, react, version, etc.) to improve readability and maintainability. 
