### PR TITLE
add review_comment type to react command

### DIFF
--- a/agent/cli/command/help/command_help.go
+++ b/agent/cli/command/help/command_help.go
@@ -35,7 +35,12 @@ Command and Flags
 
 	msg += fmt.Sprintf("  %s:\n", react.ReactCommand)
 	msg += "    Usage:\n"
-	msg += fmt.Sprintf("      %s OWNER/REPO/issues/comments/COMMENT_ID [flags]\n", react.ReactCommand)
+	msg += fmt.Sprintf("      %s RESOURCE_FORMAT [flags]\n", react.ReactCommand)
+	msg += "    RESOURCE_FORMAT:\n"
+	msg += "        issue_comment(pull request comment): OWNER/REPO/issues/comments/COMMENT_ID\n"
+	msg += "        pull_request_review_comment: OWNER/REPO/pulls/comments/COMMENT_ID\n"
+	msg += "    Example:\n"
+	msg += "       react owner/example/issues/comments/123456 [flags]\n"
 	msg += "    Flags:\n"
 	reactFlags.VisitAll(func(flg *flag.Flag) {
 		msg += fmt.Sprintf("    --%s\n", flg.Name)

--- a/agent/cli/command/react/input_react.go
+++ b/agent/cli/command/react/input_react.go
@@ -12,15 +12,15 @@ import (
 	"github.com/clover0/issue-agent/config"
 )
 
-type RecatType string
+type ReactType string
 
 const (
-	Comment       RecatType = RecatType("comment")
-	ReviewComment RecatType = RecatType("review_comment")
+	Comment       ReactType = ReactType("comment")
+	ReviewComment ReactType = ReactType("review_comment")
 )
 
 type ArgGitHubReact struct {
-	ReactType RecatType
+	ReactType ReactType
 
 	Owner      string
 	Repository string
@@ -30,7 +30,7 @@ type ArgGitHubReact struct {
 }
 
 type ReactInput struct {
-	ReactType RecatType
+	ReactType ReactType
 
 	Common         *common.CommonInput
 	GitHubOwner    string `validate:"required"`

--- a/agent/cli/command/react/input_react.go
+++ b/agent/cli/command/react/input_react.go
@@ -12,26 +12,41 @@ import (
 	"github.com/clover0/issue-agent/config"
 )
 
+type RecatType string
+
+const (
+	Comment       RecatType = RecatType("comment")
+	ReviewComment RecatType = RecatType("review_comment")
+)
+
 type ArgGitHubReact struct {
+	ReactType RecatType
+
 	Owner      string
 	Repository string
 	PRNumber   string
 	CommentID  string
+	ReviewID   string
 }
 
 type ReactInput struct {
+	ReactType RecatType
+
 	Common         *common.CommonInput
 	GitHubOwner    string `validate:"required"`
 	GithubPRNumber string
 	WorkRepository string `validate:"required"`
 	CommentID      string
+	ReviewID       string
 }
 
 func (c *ReactInput) MergeGitHubArg(react ArgGitHubReact) *ReactInput {
+	c.ReactType = react.ReactType
 	c.GitHubOwner = react.Owner
-	c.WorkRepository = react.Repository
 	c.GithubPRNumber = react.PRNumber
+	c.WorkRepository = react.Repository
 	c.CommentID = react.CommentID
+	c.ReviewID = react.ReviewID
 
 	return c
 }
@@ -71,20 +86,40 @@ func (c *ReactInput) Validate() error {
 // Expect the input to be in the bellow format.
 //
 // issue_comment(pull request): OWNER/REPO/issues/comments/COMMENT_ID
+// pull_request_review_comment: OWNER/REPO/pulls/comments/COMMENT_ID
 func BindReactGitHubArg(arg string) (ArgGitHubReact, error) {
 	commonPattern := `^(?P<owner>[^/]+)/(?P<repo>[^/]+)/`
 	issueCommentPattern := commonPattern + `issues/comments/(?P<commentID>[^/]+)$`
+	pullRequestReviewPattern := commonPattern + `pulls/comments/(?P<commentID>[^/]+)$`
 
-	// only issue comment
-	re := regexp.MustCompile(issueCommentPattern)
-	matches := re.FindStringSubmatch(arg)
-	if len(matches) == 1+3 {
-		return ArgGitHubReact{
-			Owner:      matches[re.SubexpIndex("owner")],
-			Repository: matches[re.SubexpIndex("repo")],
-			PRNumber:   "",
-			CommentID:  matches[re.SubexpIndex("commentID")],
-		}, nil
+	{
+		// handle pull request review comment
+		re := regexp.MustCompile(pullRequestReviewPattern)
+		matches := re.FindStringSubmatch(arg)
+		if len(matches) == 1+3 {
+			return ArgGitHubReact{
+				ReactType:  ReviewComment,
+				Owner:      matches[re.SubexpIndex("owner")],
+				Repository: matches[re.SubexpIndex("repo")],
+				PRNumber:   "",
+				ReviewID:   matches[re.SubexpIndex("commentID")],
+			}, nil
+		}
+	}
+
+	{
+		// handle issue comment
+		re := regexp.MustCompile(issueCommentPattern)
+		matches := re.FindStringSubmatch(arg)
+		if len(matches) == 1+3 {
+			return ArgGitHubReact{
+				ReactType:  Comment,
+				Owner:      matches[re.SubexpIndex("owner")],
+				Repository: matches[re.SubexpIndex("repo")],
+				PRNumber:   "",
+				CommentID:  matches[re.SubexpIndex("commentID")],
+			}, nil
+		}
 	}
 
 	return ArgGitHubReact{}, fmt.Errorf("failed to parse github arg: %s", arg)
@@ -103,7 +138,6 @@ func ReactFlags() (*flag.FlagSet, *ReactInput) {
 	return cmd, flagMapper
 }
 
-// ParseReactInput
 func ParseReactInput(argAndFlags []string) (ReactInput, error) {
 	arg, flags := util.ParseArgFlags(argAndFlags)
 	ghIn, err := BindReactGitHubArg(arg)

--- a/agent/cli/command/react/input_react_test.go
+++ b/agent/cli/command/react/input_react_test.go
@@ -1,0 +1,82 @@
+package react
+
+import (
+	"testing"
+
+	"github.com/clover0/issue-agent/test/assert"
+)
+
+func TestBindReactGitHubArg(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		input   string
+		want    ArgGitHubReact
+		wantErr bool
+	}{
+		"valid: pull request comment input": {
+			input: "owner/repo/issues/comments/123456",
+			want: ArgGitHubReact{
+				ReactType:  Comment,
+				Owner:      "owner",
+				Repository: "repo",
+				PRNumber:   "",
+				CommentID:  "123456",
+				ReviewID:   "",
+			},
+			wantErr: false,
+		},
+		"valid: pull request review comment input": {
+			input: "owner/repo/pulls/comments/789012",
+			want: ArgGitHubReact{
+				ReactType:  ReviewComment,
+				Owner:      "owner",
+				Repository: "repo",
+				PRNumber:   "",
+				CommentID:  "",
+				ReviewID:   "789012",
+			},
+			wantErr: false,
+		},
+		"invalid input: wrong format": {
+			input:   "owner/repo/something/comments/123456",
+			want:    ArgGitHubReact{},
+			wantErr: true,
+		},
+		"invalid input: missing comment ID": {
+			input:   "owner/repo/issues/comments/",
+			want:    ArgGitHubReact{},
+			wantErr: true,
+		},
+		"invalid input: too many segments": {
+			input:   "owner/repo/issues/comments/123456/extra",
+			want:    ArgGitHubReact{},
+			wantErr: true,
+		},
+		"invalid input: not enough segments": {
+			input:   "owner/issues/comments/123456",
+			want:    ArgGitHubReact{},
+			wantErr: true,
+		},
+		"invalid input: empty string": {
+			input:   "",
+			want:    ArgGitHubReact{},
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := BindReactGitHubArg(tt.input)
+
+			if tt.wantErr {
+				assert.HasError(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/agent/core/prompt/prompt_en.yml
+++ b/agent/core/prompt/prompt_en.yml
@@ -144,7 +144,7 @@ agents:
       <instructions>
       * Read pull request.
       * Follow the comment and complete the task.
-      * Finally you must use git_commit_push.
+      * Finally you must use submit_revision.
       </instructions>
 
   - name: review-manager

--- a/website/docs/configuration/command.md
+++ b/website/docs/configuration/command.md
@@ -41,7 +41,12 @@ Command and Flags
 
   react:
     Usage:
-      react OWNER/REPO/issues/comments/COMMENT_ID [flags]
+      react RESOURCE_FORMAT [flags]
+    RESOURCE_FORMAT:
+        issue_comment(pull request comment): OWNER/REPO/issues/comments/COMMENT_ID
+        pull_request_review_comment: OWNER/REPO/pulls/comments/COMMENT_ID
+    Example:
+       react owner/example/issues/comments/123456 [flags]
     Flags:
     --aws_profile
       AWS profile to use a specific profile from credentials.


### PR DESCRIPTION
## A new feature
Issue agent is now able to react to pull request review comment.
Add a new argument format as `OWNER/REPO/pulls/comments/COMMENT_ID` to `react` command. 

`pull_request_review_comment: OWNER/REPO/pulls/comments/COMMENT_ID` 

```
 react:
    Usage:
      react RESOURCE_FORMAT [flags]
    RESOURCE_FORMAT:
        issue_comment(pull request comment): OWNER/REPO/issues/comments/COMMENT_ID
        pull_request_review_comment: OWNER/REPO/pulls/comments/COMMENT_ID
    Example:
       react owner/example/issues/comments/123456 [flags]
```

### Review comment
Example.
![image](https://github.com/user-attachments/assets/fb374354-d704-49f9-a65c-c6fe3e81cd93)
