### PR TITLE
improve accuracy in GitHub PR review comment

### DIFF
--- a/agent/agithub/github_service.go
+++ b/agent/agithub/github_service.go
@@ -136,13 +136,16 @@ func (s GitHubService) GetReviewComment(reviewID string) (functions.GetReviewOut
 	parts := strings.Split(u.Path, "/")
 	issueNumber := parts[len(parts)-1]
 
+	startLine := review.GetOriginalStartLine()
+	if startLine == 0 {
+		startLine = review.GetOriginalLine()
+	}
 	return functions.GetReviewOutput{
 		IssuesNumber: issueNumber,
 		Path:         review.GetPath(),
-		StartLine:    review.GetStartLine(),
-		EndLine:      review.GetLine(),
+		StartLine:    startLine,
+		EndLine:      review.GetOriginalLine(),
 		Content:      review.GetBody(),
-		DiffHunk:     review.GetDiffHunk(),
 	}, nil
 
 }

--- a/agent/core/functions/get_pull_request.go
+++ b/agent/core/functions/get_pull_request.go
@@ -68,7 +68,6 @@ type GetReviewOutput struct {
 	StartLine    int
 	EndLine      int
 	Content      string
-	DiffHunk     string
 }
 
 func (g GetReviewOutput) ToLLMString() string {
@@ -82,9 +81,6 @@ The following file information received a code review.
 
 # Review content
 {{ .Content }}
-
-# Review diff hunk
-{{ .DiffHunk }}
 `
 	t, err := template.New("reviewComments").Parse(tmpl)
 	if err != nil {


### PR DESCRIPTION
Improve accuracy in GitHub PR review comment.
Remove hunk. It is noisy in agent.