### PR TITLE
add support for comment to pull request

### DIFF
--- a/agent/agithub/github_service.go
+++ b/agent/agithub/github_service.go
@@ -70,11 +70,12 @@ func (s GitHubService) GetPullRequest(prNumber string) (functions.GetPullRequest
 	}
 
 	return functions.GetPullRequestOutput{
-		Head:    pr.GetHead().GetRef(),
-		Base:    pr.GetBase().GetRef(),
-		RawDiff: diff,
-		Title:   pr.GetTitle(),
-		Content: pr.GetBody(),
+		PRNumber: prNumber,
+		Head:     pr.GetHead().GetRef(),
+		Base:     pr.GetBase().GetRef(),
+		RawDiff:  diff,
+		Title:    pr.GetTitle(),
+		Content:  pr.GetBody(),
 	}, nil
 }
 
@@ -148,5 +149,20 @@ func (s GitHubService) GetReviewComment(reviewID string) (functions.GetReviewOut
 		EndLine:      review.GetOriginalLine(),
 		Content:      review.GetBody(),
 	}, nil
+}
 
+func (s GitHubService) CreateIssueComment(issueNumber string, comment string) (functions.CreateIssueCommentOutput, error) {
+	c := context.Background()
+	number, err := strconv.Atoi(issueNumber)
+	if err != nil {
+		return functions.CreateIssueCommentOutput{}, fmt.Errorf("failed to convert issue number to int: %w", err)
+	}
+
+	issueComment := &github.IssueComment{Body: &comment}
+	_, _, err = s.client.Issues.CreateComment(c, s.owner, s.repository, number, issueComment)
+	if err != nil {
+		return functions.CreateIssueCommentOutput{}, fmt.Errorf("failed to create issue comment: %w", err)
+	}
+
+	return functions.CreateIssueCommentOutput{}, nil
 }

--- a/agent/config/default_config.yml
+++ b/agent/config/default_config.yml
@@ -75,3 +75,4 @@ agent:
     - switch_branch
     - submit_revision
     - get_issue
+    - create_pull_request_comment

--- a/agent/core/functions/create_pull_request_comment.go
+++ b/agent/core/functions/create_pull_request_comment.go
@@ -1,0 +1,49 @@
+package functions
+
+const FuncCreatePullRequestComment = "create_pull_request_comment"
+
+type CreatePullRequestCommentType func(input CreatePullRequestCommentInput) (CreateIssueCommentOutput, error)
+
+func InitCreatePullRequestCommentFunction(service GitHubService) Function {
+	f := Function{
+		Name:        FuncCreatePullRequestComment,
+		Description: "Create a comment on a GitHub pull request from `owner/repo` passed as CLI input.",
+		Func:        CreatePullRequestCommentCaller(service),
+		Parameters: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"pr_number": map[string]interface{}{
+					"type":        "string",
+					"description": "GitHub Pull Request Number to create comment to",
+				},
+				"comment": map[string]interface{}{
+					"type":        "string",
+					"description": "Comment by markdown on the pull request",
+				},
+			},
+			"required":             []string{"pr_number", "comment"},
+			"additionalProperties": false,
+		},
+	}
+
+	functionsMap[FuncCreatePullRequestComment] = f
+
+	return f
+}
+
+type CreatePullRequestCommentInput struct {
+	PRNumber string `json:"pr_number"`
+	Comment  string `json:"comment"`
+}
+
+type CreateIssueCommentOutput struct{}
+
+func (g CreateIssueCommentOutput) ToLLMString() string {
+	return "success creating pull request comment."
+}
+
+func CreatePullRequestCommentCaller(service GitHubService) CreatePullRequestCommentType {
+	return func(input CreatePullRequestCommentInput) (CreateIssueCommentOutput, error) {
+		return service.CreateIssueComment(input.PRNumber, input.Comment)
+	}
+}

--- a/agent/core/functions/functions.go
+++ b/agent/core/functions/functions.go
@@ -60,6 +60,9 @@ func InitializeFunctions(
 	if allowFunction(allowFunctions, FuncGetIssue) {
 		InitGetIssueFunction(repoService)
 	}
+	if allowFunction(allowFunctions, FuncCreatePullRequestComment) {
+		InitCreatePullRequestCommentFunction(repoService)
+	}
 }
 
 func allowFunction(allowFunctions []string, name string) bool {
@@ -285,6 +288,18 @@ func ExecFunction(l logger.Logger, store *corestore.Store, funcName FuncName, ar
 			return "", fmt.Errorf("failed to unmarshal args: %w", err)
 		}
 		out, err := functionsMap[FuncGetIssue].Func.(GetIssueType)(input)
+		if err != nil {
+			return "", err
+		}
+		return out.ToLLMString(), nil
+
+	case FuncCreatePullRequestComment:
+		l.Info("functions: do %s\n", FuncCreatePullRequestComment)
+		input := CreatePullRequestCommentInput{}
+		if err := marshalFuncArgs(argsJson, &input); err != nil {
+			return "", fmt.Errorf("failed to unmarshal args: %w", err)
+		}
+		out, err := functionsMap[FuncCreatePullRequestComment].Func.(CreatePullRequestCommentType)(input)
 		if err != nil {
 			return "", err
 		}

--- a/agent/core/functions/get_pull_request.go
+++ b/agent/core/functions/get_pull_request.go
@@ -12,6 +12,7 @@ const FuncGetPullRequest = "get_pull_request"
 type GitHubService interface {
 	GetIssue(repository string, prNumber string) (GetIssueOutput, error)
 	GetPullRequest(prNumber string) (GetPullRequestOutput, error)
+	CreateIssueComment(issueNumber string, comment string) (CreateIssueCommentOutput, error)
 }
 
 type GetPullRequestType func(input GetPullRequestInput) (GetPullRequestOutput, error)
@@ -44,11 +45,12 @@ type GetPullRequestInput struct {
 }
 
 type GetPullRequestOutput struct {
-	Head    string
-	Base    string
-	RawDiff string
-	Title   string
-	Content string
+	PRNumber string
+	Head     string
+	Base     string
+	RawDiff  string
+	Title    string
+	Content  string
 }
 
 type GetCommentOutput struct {
@@ -97,6 +99,10 @@ func (g GetPullRequestOutput) ToLLMString() string {
 	errMsg := "failed to convert pull-request to string for LLM"
 
 	tmpl := `
+<pr-number>
+{{ .PRNumber }}
+</pr-number>
+
 <pull-request-title>
 {{ .Title }}
 </pull-request-title>

--- a/agent/core/functions/get_pull_request_test.go
+++ b/agent/core/functions/get_pull_request_test.go
@@ -1,0 +1,94 @@
+package functions
+
+import (
+	"testing"
+
+	"github.com/clover0/issue-agent/test/assert"
+)
+
+func TestGetPullRequestOutput_ToLLMString(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		input    GetPullRequestOutput
+		expected string
+	}{
+		"valid pull request information": {
+			input: GetPullRequestOutput{
+				PRNumber: "123",
+				Head:     "feature-branch",
+				Base:     "main",
+				RawDiff:  "diff --git a/file.txt b/file.txt\n...",
+				Title:    "Feature: Add new functionality",
+				Content:  "This is an amazing feature",
+			},
+			expected: `
+<pr-number>
+123
+</pr-number>
+
+<pull-request-title>
+Feature: Add new functionality
+</pull-request-title>
+
+<pull-request-description>
+This is an amazing feature
+</pull-request-description>
+
+<pull-request-diff>
+diff --git a/file.txt b/file.txt
+...
+</pull-request-diff>
+`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			result := tt.input.ToLLMString()
+
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetReviewOutput_ToLLMString(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		input    GetReviewOutput
+		expected string
+	}{
+		"valid review information": {
+			input: GetReviewOutput{
+				IssuesNumber: "123",
+				Path:         "src/main.go",
+				StartLine:    10,
+				EndLine:      15,
+				Content:      "This is content",
+			},
+			expected: `
+The following file information received a code review.
+
+# Review information
+* Review file path: src/main.go
+* Review start line number: 10
+* Review end line number: 15
+
+# Review content
+This is content
+`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			result := tt.input.ToLLMString()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/agent/core/prompt/prompt_en.yml
+++ b/agent/core/prompt/prompt_en.yml
@@ -131,7 +131,6 @@ agents:
       * Use only the standard library of the programming language or use only libraries used in the repository.
       * When creating a new implementation, check carefully if it exists in any other directories.
       * Plan and run a check to see how the code you have changed works correctly without linting or compile, and fix it.
-      * Finally you must use submit_revision tool.
       </important-rules>
 
     user_prompt: |-
@@ -146,7 +145,6 @@ agents:
       <instructions>
       * Read pull request.
       * Follow the comment and complete the task.
-      * Finally you must use submit_revision.
       </instructions>
 
   - name: review-manager

--- a/agent/core/tools.go
+++ b/agent/core/tools.go
@@ -28,5 +28,6 @@ func CommentingTools() []functions.Function {
 		m[functions.FuncGetPullRequest],
 		m[functions.FuncSubmitRevision],
 		m[functions.FuncGetIssue],
+		m[functions.FuncCreatePullRequestComment],
 	}
 }

--- a/website/docs/configuration/command.md
+++ b/website/docs/configuration/command.md
@@ -83,6 +83,7 @@ Using functions:
 - switch_branch
 - submit_revision
 - get_issue
+- create_pull_request_comment
 
 
 ## `react` command
@@ -98,6 +99,7 @@ Using functions:
 - remove_file
 - submit_revision
 - get_issue
+- create_pull_request_comment
 
 
 Issue Agent does not save conversation history.

--- a/website/docs/configuration/functions.md
+++ b/website/docs/configuration/functions.md
@@ -80,5 +80,10 @@ get_issue: Get a GitHub issue from organization(owner) passed as CLI input.
     issue_number
         GitHub Issue Number to get
 
+create_pull_request_comment: Create a comment on a GitHub pull request from `owner/repo` passed as CLI input.
+    pr_number
+        GitHub Pull Request Number to create comment to
+    comment
+        Comment by markdown on the pull request
 
 ```


### PR DESCRIPTION
## New feature
Add `create_pull_request_comment` function to agent tools.

Agent can create a comment to Pull Request.