### PR TITLE
avoid max output token error

### DIFF
--- a/agent/models/anthropic_llm_forwarder.go
+++ b/agent/models/anthropic_llm_forwarder.go
@@ -273,7 +273,7 @@ func (a AnthropicLLMForwarder) createParams(input core.StartCompletionInput) (J,
 			"disable_parallel_tool_use": true,
 		},
 		"tools":      tools,
-		"max_tokens": 8192, // TODO: max_tokens
+		"max_tokens": ClaudeMaxTokens(input.Model),
 	}
 
 	return body, []core.LLMMessage{

--- a/agent/models/bedrock.go
+++ b/agent/models/bedrock.go
@@ -106,6 +106,7 @@ func (s *BedrockMessageService) Create(
 		ModelId: aws.String(modelID),
 		InferenceConfig: &types.InferenceConfiguration{
 			Temperature: pointer.Float32(0),
+			MaxTokens:   pointer.Ptr(int32(ClaudeMaxTokens(modelID))),
 		},
 		System:     []types.SystemContentBlock{&types.SystemContentBlockMemberText{Value: systemMessage}},
 		Messages:   messages,

--- a/agent/models/claude.go
+++ b/agent/models/claude.go
@@ -1,0 +1,19 @@
+package models
+
+import "strings"
+
+const (
+	Claude3_7MaxTokens = 64000
+	Claude3_5MaxTokens = 8192
+)
+
+func ClaudeMaxTokens(model string) int {
+	// https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table
+	if strings.Contains(model, "claude-3-7-sonnet-") {
+		return Claude3_7MaxTokens
+	}
+
+	// Claude-3-5.
+	// Other models are not supported.
+	return Claude3_5MaxTokens
+}

--- a/agent/models/claude_test.go
+++ b/agent/models/claude_test.go
@@ -1,0 +1,44 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/clover0/issue-agent/models"
+	"github.com/clover0/issue-agent/test/assert"
+)
+
+func TestClaudeMaxTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		model string
+		want  int
+	}{
+		"AWS Bedrock: anthropic.claude-3-7-sonnet-20250219-v1:0": {
+			model: "anthropic.claude-3-7-sonnet-20250219-v1:0",
+			want:  models.Claude3_7MaxTokens,
+		},
+		"Anthropic: claude-3-5 model": {
+			model: "claude-3-5-sonnet-20240620",
+			want:  models.Claude3_5MaxTokens,
+		},
+		"unsupported model": {
+			model: "unknown-model",
+			want:  models.Claude3_5MaxTokens,
+		},
+		"empty model string": {
+			model: "",
+			want:  models.Claude3_5MaxTokens,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			result := models.ClaudeMaxTokens(tt.model)
+
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}

--- a/agent/models/selector_test.go
+++ b/agent/models/selector_test.go
@@ -1,4 +1,4 @@
-package models
+package models_test
 
 import (
 	"os"
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/clover0/issue-agent/core"
+	"github.com/clover0/issue-agent/models"
 	"github.com/clover0/issue-agent/test/assert"
 	"github.com/clover0/issue-agent/test/loggertest"
 )
@@ -27,17 +28,17 @@ func TestSelectForwarder(t *testing.T) {
 		"AWS Bedrock model": {
 			model:    "anthropic.claude-3-5-sonnet-v1",
 			wantErr:  false,
-			wantType: BedrockLLMForwarder{},
+			wantType: models.BedrockLLMForwarder{},
 		},
 		"OpenAI model": {
 			model:    "gpt-4",
 			wantErr:  false,
-			wantType: OpenAILLMForwarder{},
+			wantType: models.OpenAILLMForwarder{},
 		},
 		"Anthropic model": {
 			model:    "claude-3",
 			wantErr:  false,
-			wantType: AnthropicLLMForwarder{},
+			wantType: models.AnthropicLLMForwarder{},
 		},
 		"Empty model": {
 			model:    "",
@@ -55,7 +56,7 @@ func TestSelectForwarder(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			forwarder, err := SelectForwarder(mockLogger, tt.model)
+			forwarder, err := models.SelectForwarder(mockLogger, tt.model)
 
 			if tt.wantErr {
 				assert.HasError(t, err)


### PR DESCRIPTION
Tackle `TODO:`.
Claude 3.7 cat output large output, so retrieve fixed `8192` value.