### PR TITLE
add function to create a review comment on GitHub pull request

### DIFF
--- a/agent/agithub/github_service.go
+++ b/agent/agithub/github_service.go
@@ -170,6 +170,7 @@ func (s GitHubService) CreateIssueComment(issueNumber string, comment string) (f
 
 func (s GitHubService) CreateReviewCommentOne(review functions.CreatePullRequestReviewCommentInput) (functions.CreatePullRequestReviewCommentOutput, error) {
 	c := context.Background()
+
 	prNumber, err := strconv.Atoi(review.PRNumber)
 	if err != nil {
 		return functions.CreatePullRequestReviewCommentOutput{}, fmt.Errorf("failed to convert prNumber to int: %w", err)
@@ -179,6 +180,7 @@ func (s GitHubService) CreateReviewCommentOne(review functions.CreatePullRequest
 	if review.ReviewStartLine == review.ReviewEndLine {
 		startLine = nil
 	}
+
 	reviewComment := []*github.DraftReviewComment{{
 		Path:      pointer.Ptr(review.ReviewFilePath),
 		Body:      pointer.Ptr(review.ReviewComment),

--- a/agent/config/default_config.yml
+++ b/agent/config/default_config.yml
@@ -76,3 +76,4 @@ agent:
     - submit_revision
     - get_issue
     - create_pull_request_comment
+    - create_pull_request_review_comment

--- a/agent/core/functions/create_pull_request_comment.go
+++ b/agent/core/functions/create_pull_request_comment.go
@@ -9,14 +9,14 @@ func InitCreatePullRequestCommentFunction(service GitHubService) Function {
 		Name:        FuncCreatePullRequestComment,
 		Description: "Create a comment on a GitHub pull request from `owner/repo` passed as CLI input.",
 		Func:        CreatePullRequestCommentCaller(service),
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"type": "object",
-			"properties": map[string]interface{}{
-				"pr_number": map[string]interface{}{
+			"properties": map[string]any{
+				"pr_number": map[string]any{
 					"type":        "string",
 					"description": "GitHub Pull Request Number to create comment to",
 				},
-				"comment": map[string]interface{}{
+				"comment": map[string]any{
 					"type":        "string",
 					"description": "Comment by markdown on the pull request",
 				},

--- a/agent/core/functions/create_pull_request_review_comment.go
+++ b/agent/core/functions/create_pull_request_review_comment.go
@@ -1,0 +1,66 @@
+package functions
+
+const FuncCreatePullRequestReviewComment = "create_pull_request_review_comment"
+
+type CreatePullRequestReviewCommentType func(input CreatePullRequestReviewCommentInput) (CreatePullRequestReviewCommentOutput, error)
+
+func InitCreatePullRequestReviewCommentFunction(service GitHubService) Function {
+	f := Function{
+		Name:        FuncCreatePullRequestReviewComment,
+		Description: "Create a review comment on a GitHub pull request for a specific file and line range.",
+		Func:        CreatePullRequestReviewCommentCaller(service),
+		Parameters: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"pr_number": map[string]interface{}{
+					"type":        "string",
+					"description": "GitHub Pull Request Number to create comment to",
+				},
+				"review_file_path": map[string]interface{}{
+					"type":        "string",
+					"description": "File path from repository root for review",
+				},
+				"review_start_line": map[string]interface{}{
+					"type":        "number",
+					"description": "Review start line number on file",
+					"minimum":     1,
+				},
+				"review_end_line": map[string]interface{}{
+					"type":        "number",
+					"description": "Review end line number on file",
+					"minimum":     1,
+				},
+				"review_comment": map[string]interface{}{
+					"type":        "string",
+					"description": "Comment to be added to the pull request review",
+				},
+			},
+			"required":             []string{"pr_number", "review_file_path", "review_start_line", "review_end_line", "review_comment"},
+			"additionalProperties": false,
+		},
+	}
+
+	functionsMap[FuncCreatePullRequestReviewComment] = f
+
+	return f
+}
+
+type CreatePullRequestReviewCommentInput struct {
+	PRNumber        string `json:"pr_number"`
+	ReviewFilePath  string `json:"review_file_path"`
+	ReviewStartLine int    `json:"review_start_line"`
+	ReviewEndLine   int    `json:"review_end_line"`
+	ReviewComment   string `json:"review_comment"`
+}
+
+type CreatePullRequestReviewCommentOutput struct{}
+
+func (g CreatePullRequestReviewCommentOutput) ToLLMString() string {
+	return "success creating pull request review comment."
+}
+
+func CreatePullRequestReviewCommentCaller(service GitHubService) CreatePullRequestReviewCommentType {
+	return func(input CreatePullRequestReviewCommentInput) (CreatePullRequestReviewCommentOutput, error) {
+		return service.CreateReviewCommentOne(input)
+	}
+}

--- a/agent/core/functions/functions.go
+++ b/agent/core/functions/functions.go
@@ -63,6 +63,9 @@ func InitializeFunctions(
 	if allowFunction(allowFunctions, FuncCreatePullRequestComment) {
 		InitCreatePullRequestCommentFunction(repoService)
 	}
+	if allowFunction(allowFunctions, FuncCreatePullRequestReviewComment) {
+		InitCreatePullRequestReviewCommentFunction(repoService)
+	}
 }
 
 func allowFunction(allowFunctions []string, name string) bool {
@@ -300,6 +303,18 @@ func ExecFunction(l logger.Logger, store *corestore.Store, funcName FuncName, ar
 			return "", fmt.Errorf("failed to unmarshal args: %w", err)
 		}
 		out, err := functionsMap[FuncCreatePullRequestComment].Func.(CreatePullRequestCommentType)(input)
+		if err != nil {
+			return "", err
+		}
+		return out.ToLLMString(), nil
+
+	case FuncCreatePullRequestReviewComment:
+		l.Info("functions: do %s\n", FuncCreatePullRequestReviewComment)
+		input := CreatePullRequestReviewCommentInput{}
+		if err := marshalFuncArgs(argsJson, &input); err != nil {
+			return "", fmt.Errorf("failed to unmarshal args: %w", err)
+		}
+		out, err := functionsMap[FuncCreatePullRequestReviewComment].Func.(CreatePullRequestReviewCommentType)(input)
 		if err != nil {
 			return "", err
 		}

--- a/agent/core/functions/get_pull_request.go
+++ b/agent/core/functions/get_pull_request.go
@@ -13,6 +13,7 @@ type GitHubService interface {
 	GetIssue(repository string, prNumber string) (GetIssueOutput, error)
 	GetPullRequest(prNumber string) (GetPullRequestOutput, error)
 	CreateIssueComment(issueNumber string, comment string) (CreateIssueCommentOutput, error)
+	CreateReviewCommentOne(input CreatePullRequestReviewCommentInput) (CreatePullRequestReviewCommentOutput, error)
 }
 
 type GetPullRequestType func(input GetPullRequestInput) (GetPullRequestOutput, error)

--- a/agent/core/tools.go
+++ b/agent/core/tools.go
@@ -29,5 +29,6 @@ func CommentingTools() []functions.Function {
 		m[functions.FuncSubmitRevision],
 		m[functions.FuncGetIssue],
 		m[functions.FuncCreatePullRequestComment],
+		m[functions.FuncCreatePullRequestReviewComment],
 	}
 }

--- a/website/docs/configuration/command.md
+++ b/website/docs/configuration/command.md
@@ -100,6 +100,7 @@ Using functions:
 - submit_revision
 - get_issue
 - create_pull_request_comment
+- create_pull_request_review_comment
 
 
 Issue Agent does not save conversation history.

--- a/website/docs/configuration/functions.md
+++ b/website/docs/configuration/functions.md
@@ -86,4 +86,16 @@ create_pull_request_comment: Create a comment on a GitHub pull request from `own
     comment
         Comment by markdown on the pull request
 
+create_pull_request_review_comment: Create a review comment on a GitHub pull request for a specific file and line range.
+    pr_number
+        GitHub Pull Request Number to create comment to
+    review_file_path
+        File path from repository root for review
+    review_start_line
+        Review start line number on file
+    review_end_line
+        Review end line number on file
+    review_comment
+        Comment to be added to the pull request review
+
 ```


### PR DESCRIPTION
## Update (New function)
This update introduces the `create_pull_request_review_comment` function, enabling the addition of review comments to specific lines in a GitHub pull request. 

## Example
In Pull Request Comment,
```
Please review the following from a web security perspective.  
When reviewing, include the actual reference URL to support your comments.  
To leave a review comment, use only  `create_pull_request_review_comment`.
```

Result,

![result](https://github.com/user-attachments/assets/ec886204-5973-4a89-9883-28138341e877)
