### PR TITLE
improve feedback when branch not found error

### DIFF
--- a/agent/agithub/clone_repository.go
+++ b/agent/agithub/clone_repository.go
@@ -1,6 +1,7 @@
 package agithub
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -25,6 +26,9 @@ func CloneRepository(lo logger.Logger, conf config.Config, workRepository string
 		Depth:         1,
 		ReferenceName: plumbing.ReferenceName(refBranch),
 	}); err != nil {
+		if errors.Is(err, plumbing.ErrReferenceNotFound) {
+			return fmt.Errorf("branch %s not found in repository %s/%s\n", refBranch, conf.Agent.GitHub.Owner, workRepository)
+		}
 		return err
 	}
 	lo.Info("cloned repository successfully\n")

--- a/agent/cli/command/createpr/command_create_pr.go
+++ b/agent/cli/command/createpr/command_create_pr.go
@@ -36,7 +36,7 @@ func CreatePR(flags []string) error {
 
 	if *conf.Agent.GitHub.CloneRepository {
 		if err := agithub.CloneRepository(lo, conf, cliIn.WorkRepository, cliIn.BaseBranch); err != nil {
-			lo.Error("failed to clone repository")
+			lo.Error("failed to clone repository\n")
 			return err
 		}
 	}


### PR DESCRIPTION
Added `reference not found` error handling for cases where a branch is not found during the repository cloning process