### PR TITLE
remove support for `review_agents` configuration

### DIFF
--- a/agent/cli/command/createpr/input_create_pr.go
+++ b/agent/cli/command/createpr/input_create_pr.go
@@ -18,7 +18,6 @@ type CreatePRInput struct {
 	GithubIssueNumber string
 	WorkRepository    string `validate:"required"`
 	BaseBranch        string `validate:"required"`
-	ReviewAgents      int
 	Reviewers         reviewers
 	TeamReviewers     reviewers
 }
@@ -59,10 +58,6 @@ func (c *CreatePRInput) MergeConfig(conf config.Config) config.Config {
 		conf.Agent.GitHub.Owner = c.GitHubOwner
 	}
 
-	if c.ReviewAgents > 0 {
-		conf.Agent.ReviewAgents = c.ReviewAgents
-	}
-
 	if len(c.TeamReviewers) > 0 {
 		conf.Agent.GitHub.TeamReviewers = c.TeamReviewers
 	}
@@ -95,8 +90,6 @@ func CreatePRFlags() (*flag.FlagSet, *CreatePRInput) {
 	common.AddCommonFlags(cmd, flagMapper.Common)
 
 	cmd.StringVar(&flagMapper.BaseBranch, "base_branch", "", "Base Branch for pull request")
-	cmd.IntVar(&flagMapper.ReviewAgents, "review_agents", 0, `The number of agents to review. A value greater than 0 will review to the created PR.
-Default: 0`)
 	cmd.Var(&flagMapper.Reviewers, "reviewers", "The list of GitHub user `login` as reviewers. If you want to add multiple reviewers, separate them with a comma.")
 	cmd.Var(&flagMapper.TeamReviewers, "team_reviewers", "The list of GitHub Team `slug` as team_reviewers. If you want to add multiple team reviewers, separate them with a comma.")
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -27,10 +27,9 @@ type Config struct {
 	WorkDir  string `yaml:"workdir"`
 	LogLevel string `yaml:"log_level" validate:"log_level"`
 	Agent    struct {
-		Model        string `yaml:"model" validate:"required"`
-		MaxSteps     int    `yaml:"max_steps" validate:"gte=0"`
-		ReviewAgents int    `yaml:"review_agents"`
-		Git          struct {
+		Model    string `yaml:"model" validate:"required"`
+		MaxSteps int    `yaml:"max_steps" validate:"gte=0"`
+		Git      struct {
 			UserName  string `yaml:"user_name"`
 			UserEmail string `yaml:"user_email"`
 		} `yaml:"git"`

--- a/agent/config/default_config.yml
+++ b/agent/config/default_config.yml
@@ -24,12 +24,6 @@ agent:
   # - execution function
   max_steps: 70
 
-  # The number of agents to review.
-  # If a value greater than 0 is specified,
-  # then that number of reviews will be performed by agents with different roles.
-  # Default is 0
-  review_agents: 0
-
   git:
     # git user name
     user_name: "github-actions[bot]"

--- a/agent/core/orchestrator.go
+++ b/agent/core/orchestrator.go
@@ -1,9 +1,7 @@
 package core
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -17,7 +15,6 @@ import (
 	corestore "github.com/clover0/issue-agent/core/store"
 	"github.com/clover0/issue-agent/logger"
 	"github.com/clover0/issue-agent/util"
-	"github.com/clover0/issue-agent/util/pointer"
 )
 
 // OrchestrateAgentsByIssue orchestrates agents
@@ -120,138 +117,10 @@ func OrchestrateAgentsByIssue(
 		lo.Error("failed build developer prompt: %s\n", err)
 		return err
 	}
-	developerAgent, err := RunAgent("developerAgent",
-		prompt, parameter, lo, &dataStore, llmForwarder, tools)
-	if err != nil {
+
+	if _, err := RunAgent("developerAgent", prompt, parameter, lo, &dataStore, llmForwarder, tools); err != nil {
 		lo.Error("developer agent failed: %s\n", err)
 		return err
-	}
-
-	if conf.Agent.ReviewAgents == 0 {
-		lo.Info("skip review agents\n")
-		lo.Info("agents finished work\n")
-		return nil
-	}
-
-	if s := dataStore.GetSubmittedWork(corestore.LastSubmissionKey); s == nil {
-		lo.Error("submission is not found\n")
-		return err
-	}
-	submittedPRNumber := dataStore.GetSubmittedWork(corestore.LastSubmissionKey).PullRequestNumber
-
-	prompt, err = coreprompt.BuildReviewManagerPrompt(
-		promptTemplate, conf, issue, util.Map(developerAgent.ChangedFiles(), func(f corestore.File) string { return f.Path }), baseBranch)
-	if err != nil {
-		lo.Error("failed to build review manager prompt: %s\n", err)
-		return err
-	}
-	reviewManager, err := RunAgent(
-		"reviewManagerAgent",
-		prompt,
-		parameter,
-		lo, &dataStore, llmForwarder, functions.AllFunctions())
-	if err != nil {
-		lo.Error("reviewManagerAgent failed: %s\n", err)
-		return err
-	}
-	output := reviewManager.LastHistory().RawContent
-	lo.Info("ReviewManagerAgent output: %s\n", output)
-	type agentPrompt struct {
-		AgentName string `json:"agent_name"`
-		Prompt    string `json:"prompt"`
-	}
-
-	// FIXME: these code is fragile
-	// parse json output for reviewer agents
-	// expected output:
-	//   text text text...
-	//   [{"agent_name": "agent1", "prompt": "prompt1"}, ...]
-	//   test...
-	var prompts []agentPrompt
-	jsonStart := strings.Index(output, "[")   // find JSON start
-	jsonEnd := strings.LastIndex(output, "]") // find JSON end
-	jsonLike := output[jsonStart : jsonEnd+1]
-	jsonLike = strings.ReplaceAll(jsonLike, "\n", `\\n`)
-	outBuff := bytes.NewBufferString(jsonLike)
-	if err := json.Unmarshal(outBuff.Bytes(), &prompts); err != nil {
-		lo.Error("failed to unmarshal output: %s\n", err)
-		return err
-	}
-
-	for _, p := range prompts {
-		lo.Info("Run %s\n", p.AgentName)
-		prpt, err := coreprompt.BuildReviewerPrompt(promptTemplate, conf.Language, submittedPRNumber, p.Prompt)
-		if err != nil {
-			lo.Error("failed to build reviewer prompt: %s\n", err)
-			return err
-		}
-
-		reviewer, err := RunAgent(
-			p.AgentName,
-			prpt,
-			parameter,
-			lo, &dataStore, llmForwarder, functions.AllFunctions())
-		if err != nil {
-			lo.Error("%s failed: %s\n", p.AgentName, err)
-			return err
-		}
-		output := reviewer.LastHistory().RawContent
-
-		// parse JSON output
-		// TODO: validate
-		var reviews []struct {
-			ReviewFilePath  string `json:"review_file_path"`
-			ReviewStartLine int    `json:"review_start_line"`
-			ReviewEndLine   int    `json:"review_end_line"`
-			ReviewComment   string `json:"review_comment"`
-			Suggestion      string `json:"suggestion"`
-		}
-		jsonStart := strings.Index(output, "[")   // find JSON start
-		jsonEnd := strings.LastIndex(output, "]") // find JSON end
-		jsonStr := strings.ReplaceAll(output[jsonStart:jsonEnd+1], "\n", `\\n`)
-		outBuff := bytes.NewBufferString(jsonStr)
-		if err := json.Unmarshal(outBuff.Bytes(), &reviews); err != nil {
-			lo.Error("failed to unmarshal output: %s\n", err)
-			return err
-		}
-
-		// TODO: move to agithub package
-		var comments []*github.DraftReviewComment
-		for _, r := range reviews {
-			startLine := pointer.Ptr(r.ReviewStartLine)
-			if *startLine == 0 {
-				*startLine = 1
-			}
-			if r.ReviewStartLine == r.ReviewEndLine {
-				startLine = nil
-			}
-			body := fmt.Sprintf("from %s\n", p.AgentName) +
-				r.ReviewComment
-			if r.Suggestion != "" {
-				// TODO: escape JSON in Suggestion string
-				body += "\n\n```suggestion\n" + r.Suggestion + "\n```\n"
-			}
-			comments = append(comments, &github.DraftReviewComment{
-				Path:      pointer.Ptr(r.ReviewFilePath),
-				Body:      pointer.Ptr(body),
-				StartLine: startLine,
-				Line:      pointer.Ptr(r.ReviewEndLine),
-				Side:      pointer.Ptr("RIGHT"),
-			})
-		}
-
-		if _, _, err := gh.PullRequests.CreateReview(context.Background(),
-			conf.Agent.GitHub.Owner,
-			workRepository,
-			submittedPRNumber,
-			&github.PullRequestReviewRequest{
-				Event:    pointer.Ptr("COMMENT"),
-				Comments: comments,
-			},
-		); err != nil {
-			lo.Error("failed to create pull request review: %s. but agent continue to work\n", err)
-		}
-		lo.Info("finish %s\n", p.AgentName)
 	}
 
 	lo.Info("agents finished work\n")

--- a/agent/core/prompt/prompt_builder.go
+++ b/agent/core/prompt/prompt_builder.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/clover0/issue-agent/config"
 	"github.com/clover0/issue-agent/core/functions"
 )
 
@@ -55,41 +54,6 @@ func BuildCommentReactorPrompt(promptTpl Template, language string,
 		"issueNumber":   comment.IssueNumber,
 		"comment":       comment.Content,
 		"prLLMString":   pr.ToLLMString(),
-	})
-}
-
-func BuildReviewManagerPrompt(promptTpl Template, cnf config.Config, issue functions.GetIssueOutput, changedFilesPath []string, baseBranch string) (Prompt, error) {
-	m := make(map[string]any)
-
-	m["language"] = cnf.Language
-	m["filePaths"] = changedFilesPath
-	m["issue"] = issue.Content
-	m["reviewAgents"] = cnf.Agent.ReviewAgents
-	m["baseBranch"] = baseBranch
-
-	m["noFiles"] = ""
-	if len(changedFilesPath) == 0 {
-		m["noFiles"] = "no changed files"
-	}
-
-	tmpl, err := FindPromptTemplate(promptTpl, "review-manager")
-	if err != nil {
-		return Prompt{}, fmt.Errorf("failed to find review-manager prompt template: %w", err)
-	}
-
-	return BuildPrompt(tmpl, m)
-}
-
-func BuildReviewerPrompt(promptTpl Template, language string, prNumber int, reviewerPrompt string) (Prompt, error) {
-	tmpl, err := FindPromptTemplate(promptTpl, "reviewer")
-	if err != nil {
-		return Prompt{}, fmt.Errorf("failed to find reviewer prompt template: %w", err)
-	}
-
-	return BuildPrompt(tmpl, map[string]any{
-		"language":       language,
-		"prNumber":       prNumber,
-		"reviewerPrompt": reviewerPrompt,
 	})
 }
 

--- a/website/docs/configuration/command.md
+++ b/website/docs/configuration/command.md
@@ -30,10 +30,6 @@ Command and Flags
       Default: info.
     --model
       LLM name. For the model name, check the documentation of each LLM provider.
-    --review_agents
-      The number of agents to review.
-      If a value greater than 0 is specified, then that number of reviews will be performed by agents with different roles.
-      Default: 0
     --reviewers
       The list of GitHub user `login` as reviewers. If you want to add multiple reviewers, separate them with a comma.
     --team_reviewers


### PR DESCRIPTION
This commit removes the `review_agents` parameter across the codebase, simplifying agent configuration and related functionality. 
Associated fields, flags, prompts, and logic for handling review agents have been deleted to streamline the code. 
